### PR TITLE
Add one step checkout functionality

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/stock_inventory_manager.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_inventory_manager.js
@@ -1,0 +1,139 @@
+function StockInventoryManager(inputs) {
+  this.selectBox = inputs.selectBox;
+  this.stocksContainer = inputs.stocksContainer;
+  this.valid = false;
+}
+
+StockInventoryManager.prototype.init = function() {
+  this.bindEvents();
+};
+
+StockInventoryManager.prototype.bindEvents = function() {
+  this.stockLocationChangeEvent();
+  this.numberSpinnerEvent();
+  this.stockChangeValidateEvent();
+  this.stockItemBackorderableEvent();
+  this.stockChangeSubmitEvent();
+};
+
+// when stock location is changed
+StockInventoryManager.prototype.stockLocationChangeEvent = function() {
+  var _this = this;
+  this.selectBox.on('change', function() {
+    var selectedOption = $(this).find(':selected');
+    _this.loadStocks(selectedOption);
+  });
+};
+
+// when we click +/- option for increasing and decrementing stock
+StockInventoryManager.prototype.numberSpinnerEvent = function() {
+  var _this = this;
+  this.stocksContainer.on('click', '[data-toggle="number_spinner"]', function() {
+    var $element = $(this).parents('[data-hook="admin_stock_management_index_rows"]')
+                          .find('[data-hook="number_spinner"]'),
+      action = $(this).data('value'),
+      oldValue = $element.data('oldValue'),
+      quantity = Number($element.val());
+    if (action === 'increase') {
+      $element.val(quantity + 1);
+    } else {
+      $element.val(quantity - 1);
+    }
+    _this.valid = _this.validateStockCount($element, oldValue);
+  });
+};
+
+// when stock count is changed in the text field next to the stock item
+StockInventoryManager.prototype.stockChangeValidateEvent = function() {
+  var _this = this;
+  // Validate after focus lost
+  this.stocksContainer.on('blur', '[data-hook="number_spinner"]', function() {
+    var $element = $(this);
+    _this.valid = _this.validateStockCount($element, $element.data('oldValue'));
+  });
+};
+
+// when stock item is made backorderable
+StockInventoryManager.prototype.stockItemBackorderableEvent = function() {
+  var _this = this;
+  this.stocksContainer.on('click', '[data-hook="stock_item_backorderable"]', function() {
+    _this.valid = true;
+  });
+};
+
+// save event of changed stock item
+StockInventoryManager.prototype.stockChangeSubmitEvent = function() {
+  var _this = this;
+  this.stocksContainer.on('click', '[data-hook="stock_item_submit"]', function(event) {
+    event.preventDefault();
+    if (_this.valid) {
+      var $stockItem = $(this).parents('[data-hook="admin_stock_management_index_rows"]'),
+        $element = $stockItem.find('[data-hook="number_spinner"]'),
+        $stockQuantityElement = $stockItem.find('input[data-hook="stock_movement_quantity"]');
+      $.ajax({
+        method: 'POST',
+        url: $(this).data('href'),
+        data: {
+          authenticity_token: AUTH_TOKEN
+        },
+        beforeSend: function(jqXHR, settings) {
+          var quantity = Number($element.val() - $element.data('oldValue'));
+          $stockQuantityElement.val(quantity);
+          settings.data += '&' + $stockItem.find('[data-behavior="form"]').serialize();
+        },
+        success: function(response) {
+          $element.data('oldValue', response.stock_item.count_on_hand);
+          $stockItem.find('[data-hook="current_count_on_hand"]').html(response.stock_item.count_on_hand);
+          show_flash('success', response.message);
+        },
+        error: function(response) {
+          show_flash('error', response.responseJSON.errors);
+        }
+      });
+    }
+  });
+};
+
+StockInventoryManager.prototype.validateStockCount = function($element, oldValue) {
+  // Check for insane values
+  var value = Number($element.val());
+  if (isNaN(value)) {
+    $element.val(oldValue);
+    return false;
+  } else {
+    return true;
+  }
+};
+
+StockInventoryManager.prototype.loadStocks = function($selectedOption) {
+  var url = $selectedOption.data('url');
+  window.history.pushState({}, '', url);
+  $.ajax({
+    method: 'GET',
+    url: url,
+    dataType: 'script',
+    cache: true,
+    success: function() {
+      $('.js-per-page-select').change(function() {
+        var form  = $(this).closest('.js-per-page-form');
+        var url   = form.attr('action');
+        var value = $(this).val().toString();
+        if (url.match(/\?/)) {
+          url += '&per_page=' + value;
+        } else {
+          url += '?per_page=' + value;
+        }
+        window.location = url;
+      });
+    }
+  });
+};
+
+$(function() {
+  var inputs = {
+    selectBox: $('select[data-hook="stock-location-selector"]'),
+    stocksContainer: $('[data-hook="admin_stock_inventory_management"]')
+  },
+    stockInventoryManager = new StockInventoryManager(inputs);
+  stockInventoryManager.init();
+});

--- a/backend/app/assets/javascripts/spree/backend/stock_management.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management.js.coffee
@@ -1,7 +1,7 @@
 jQuery ->
-  $('.stock_item_backorderable').on 'click', ->
+  $('[data-hook="admin_stock_inventory_management"]').on 'click', '.stock_item_backorderable', ->
     $(@).parent('form').submit()
-  $('.toggle_stock_item_backorderable').on 'submit', ->
+  $('[data-hook="admin_stock_inventory_management"]').on 'submit', '.toggle_stock_item_backorderable', ->
     $.ajax
       type: @method
       url: @action

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -23,3 +23,34 @@ body {
 .alert-error {
   @extend .alert-danger;
 }
+
+.padding-top-none {
+  padding-top: 0 !important;
+}
+
+.padding-bottom-none {
+  padding-bottom: 0 !important;
+}
+
+.padding-left-none {
+  padding-left: 0 !important;
+}
+
+.padding-right-none {
+  padding-right: 0 !important;
+}
+
+.padding-none-horizontal {
+  @extend .padding-left-none;
+  @extend .padding-right-none;
+}
+
+.padding-none-vertical {
+  @extend .padding-top-none;
+  @extend .padding-bottom-none;
+}
+
+.padding-none {
+  @extend .padding-none-horizontal;
+  @extend .padding-none-vertical;
+}

--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -1,51 +1,92 @@
 module Spree
   module Admin
-    class StockItemsController < Spree::Admin::BaseController
+    class StockItemsController < ResourceController
       before_action :determine_backorderable, only: :update
 
       def update
-        stock_item.save
+        @stock_item.save
         respond_to do |format|
           format.js { head :ok }
         end
       end
 
       def create
-        variant = Variant.find(params[:variant_id])
-        stock_location = StockLocation.find(params[:stock_location_id])
         stock_movement = stock_location.stock_movements.build(stock_movement_params)
         stock_movement.stock_item = stock_location.set_up_stock_item(variant)
 
         if stock_movement.save
-          flash[:success] = flash_message_for(stock_movement, :successfully_created)
+          respond_to do |format|
+            format.json { render json: { stock_item: stock_movement.stock_item, message: flash_message_for(stock_movement, :successfully_created) } }
+            format.html do
+              flash[:success] = flash_message_for(stock_movement, :successfully_created)
+              redirect_back fallback_location: spree.stock_admin_product_url(variant.product)
+            end
+          end
         else
-          flash[:error] = Spree.t(:could_not_create_stock_movement)
+          respond_to do |format|
+            format.json do
+              render json: {
+                errors: stock_movement.errors.full_messages + stock_movement.stock_item.errors.full_messages,
+                message: Spree.t(:could_not_create_stock_movement)
+              }, status: :unprocessable_entity
+            end
+            format.html do
+              flash[:error] = Spree.t(:could_not_create_stock_movement)
+              redirect_back fallback_location: spree.stock_admin_product_url(variant.product)
+            end
+          end
         end
-
-        redirect_back fallback_location: spree.stock_admin_product_url(variant.product)
       end
 
       def destroy
-        stock_item.destroy
+        @stock_item.destroy
 
         respond_with(@stock_item) do |format|
-          format.html { redirect_back fallback_location: spree.stock_admin_product_url(stock_item.product) }
+          format.html { redirect_back fallback_location: spree.stock_admin_product_url(@stock_item.product) }
           format.js
         end
       end
 
       private
-        def stock_movement_params
-          params.require(:stock_movement).permit(permitted_stock_movement_attributes)
-        end
 
-        def stock_item
-          @stock_item ||= StockItem.find(params[:id])
-        end
+      def stock_movement_params
+        params.require(:stock_movement).permit(permitted_stock_movement_attributes)
+      end
 
-        def determine_backorderable
-          stock_item.backorderable = params[:stock_item].present? && params[:stock_item][:backorderable].present?
-        end
+      def stock_location
+        @stock_location_class ||= StockLocation.accessible_by(current_ability, :read)
+        @stock_location ||= @stock_location_class.find_by(id: params[:stock_location_id]) ||
+                            @stock_location_class.find_by(name: params[:stock_location]) ||
+                            @stock_location_class.first
+      end
+
+      def determine_backorderable
+        @stock_item.backorderable = params[:stock_item].present? && params[:stock_item][:backorderable].present?
+      end
+
+      def variant
+        @variant ||= Variant.find(params[:variant_id])
+      end
+
+      def collection
+        return @collection if @collection.present?
+        # params[:q] can be blank upon pagination
+        params[:q] = {} if params[:q].blank?
+        @collection = stock_location.
+                      stock_items.
+                      accessible_by(current_ability, :read).
+                      includes(variant: [:product, :images, option_values: :option_type]).
+                      order("#{Spree::Variant.table_name}.product_id")
+
+        @search = @collection.ransack(params[:q])
+        @collection = @search.result.
+                      page(params[:page]).
+                      per(params[:per_page] || Spree::Config[:stock_items_per_page])
+      end
+
+      def stock_item_params
+        params.require(:stock_item).permit(permitted_stock_item_attributes)
+      end
     end
   end
 end

--- a/backend/app/helpers/spree/admin/stock_items_helper.rb
+++ b/backend/app/helpers/spree/admin/stock_items_helper.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Admin
+    module StockItemsHelper
+      def search_params
+        params[:q].permit(:variant_product_name_cont, :variant_sku_cont).to_h
+      end
+    end
+  end
+end

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -17,5 +17,6 @@ module Spree
                             :reimbursement_types, :return_authorization_reasons]
     PROMOTION_TABS     ||= [:promotions, :promotion_categories]
     USER_TABS          ||= [:users]
+    STOCKS_TABS        ||= [:stock_items]
   end
 end

--- a/backend/app/views/spree/admin/products/stock.html.erb
+++ b/backend/app/views/spree/admin/products/stock.html.erb
@@ -7,7 +7,7 @@
   </div>
 <% end %>
 
-<div class="panel panel-default">
+<div class="panel panel-default"  data-hook='admin_stock_inventory_management'>
   <table class="table table-bordered" id="listing_product_stock">
     <thead>
       <tr data-hook="admin_product_stock_management_index_headers">

--- a/backend/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_main_menu.html.erb
@@ -40,6 +40,12 @@
   </ul>
 <% end %>
 
+<% if can? :admin, Spree::StockItem %>
+  <ul class="nav nav-sidebar">
+    <%= tab *Spree::BackendConfiguration::STOCKS_TABS, icon: 'th-list' %>
+  </ul>
+<% end %>
+
 <% if can? :admin, current_store && Spree::Config[:admin_show_version] %>
   <div class="spree-version hidden-xs hidden-sm">
     <%= Spree.version %>

--- a/backend/app/views/spree/admin/stock_items/_custom_table_options.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_custom_table_options.html.erb
@@ -1,0 +1,13 @@
+<div class="row index-pagination-row">
+  <div class="col-sm-6">
+    <%= paginate collection, params: { stock_location: params[:stock_location] || @stock_location.id } %>
+  </div>
+  <div class="col-sm-6">
+    <div class="pagination-wrap">
+      <%= form_tag(per_page_dropdown_params(params), { method: :get, class: 'js-per-page-form form-inline' }) do %>
+        <%= per_page_dropdown %>
+      <% end %>
+      <div class="clearfix"></div>
+    </div>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/stock_items/_stock_items.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_items.html.erb
@@ -1,0 +1,77 @@
+<%= render partial: 'custom_table_options', locals: { collection: @collection } %>
+
+<div class="panel panel-default">
+  <table class="table table-bordered table-responsive" id="listing_stock">
+    <thead>
+      <tr data-hook="admin_product_stock_management_index_headers">
+        <th class="text-center"><%= Spree.t(:variant) %></th>
+        <th class="text-center"><%= Spree.t(:product_name) %></th>
+        <th colspan="2" class="text-center"><%= Spree.t(:sku_and_options_text) %></th>
+        <th class="text-center"><%= Spree.t(:current_count_on_hand) %></th>
+        <th colspan="3" class="text-center"><%= Spree.t(:quantity) %></th>
+        <th class="text-center"><%= Spree.t(:backorderable) %></th>
+        <th class="actions text-center"></th>
+      </tr>
+    </thead>
+    <tbody id='stock-inventory'>
+      <% @collection.each do |stock_item| %>
+        <tr id="stock-item-<%= stock_item.id %>" data-hook="admin_stock_management_index_rows" >
+          <td class="image text-center">
+            <% if stock_item.variant.images.present? %>
+              <%= image_tag stock_item.variant.images.first.attachment.url(:mini) %>
+            <% end %>
+          </td>
+          <td class="text-center"><%= stock_item.product.name %></td>
+          <td colspan="2" class="text-center">
+            <%= stock_item.variant.sku_and_options_text %>
+          </td>
+          <td class="text-center" data-hook='current_count_on_hand'>
+            <%= stock_item.count_on_hand %>
+          </td>
+          <td colspan="3" class="text-center">
+            <div class="input-group" data-hook='stock-count'>
+              <span class="input-group-btn data-dwn">
+                <%= link_to 'javascript:void(0)', class: "btn btn-danger",
+                  data: { value: "decrease", target: "#number_spinner", toggle: "number_spinner" } do %>
+                  <span class="glyphicon glyphicon-minus"></span>
+                <% end %>
+              </span>
+
+                <%= text_field_tag 'total_stock_quantity', stock_item.count_on_hand, id: "number_spinner",
+                  size: "2", class: "text-center form-control input-number",
+                  data: { hook: 'number_spinner', old_value: stock_item.count_on_hand } %>
+
+              <span class="input-group-btn data-up">
+                <%= link_to 'javascript:void(0)', class: "btn btn-success",
+                  data: { value: "increase", target: "#number_spinner", toggle: "number_spinner" } do %>
+                  <span class="glyphicon glyphicon-plus"></span>
+                <% end %>
+              </span>
+              <%= hidden_field_tag 'stock_movement[quantity]', 0, data: { hook: 'stock_movement_quantity', behavior: 'form' } %>
+              <%= hidden_field_tag :stock_location_id, @stock_location.id, data: { hook: 'stock_location_id', behavior: 'form' } %>
+              <%= hidden_field_tag :variant_id, stock_item.variant_id, data: { hook: 'variant_id', behavior: 'form' } %>
+              &nbsp;&nbsp; &nbsp;
+              <span class="input-group-btn">
+                <%= link_to Spree.t(:save, scope: :actions), 'javascript:void(0)', class: 'submit btn btn-primary action-save',
+                data: { stock_item: stock_item.id, hook: 'stock_item_submit', href: admin_stock_items_path(stock_item, format: :json) } %>
+              </span>
+            </div>
+          </td>
+          <td class="text-center">
+            <%= form_tag admin_stock_item_path(stock_item, format: :js), method: :put, class: 'toggle_stock_item_backorderable' do %>
+              <%= check_box_tag 'stock_item[backorderable]', true,
+                stock_item.backorderable?,
+                class: 'stock_item_backorderable',
+                id: "stock_item_backorderable_#{stock_item.stock_location.id}" %>
+            <% end if can? :update, stock_item %>
+          </td>
+          <td class="actions actions-1 text-center">
+            <%= link_to_with_icon('delete', Spree.t(:remove), [:admin, stock_item], method: :delete, remote: true, class: 'icon_link btn btn-danger btn-sm', data: { action: :remove, confirm: Spree.t(:are_you_sure) }, no_text: true) if can? :destroy, stock_item %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<%= render partial: 'custom_table_options', locals: { collection: @collection } %>

--- a/backend/app/views/spree/admin/stock_items/index.html.erb
+++ b/backend/app/views/spree/admin/stock_items/index.html.erb
@@ -1,0 +1,46 @@
+<% content_for :page_title do %>
+  <%= plural_resource_name(Spree::StockItem) %>
+<% end %>
+
+<% content_for :table_filter do %>
+  <div data-hook="admin_products_sidebar">
+    <%= search_form_for [:admin, @search] do |f| %>
+      <div data-hook="admin_stock_itemss_index_search" class="row">
+        <div class="col-md-6">
+          <div class="form-group">
+            <%= f.label :variant_product_name_cont, Spree.t(:name) %>
+            <%= f.text_field :variant_product_name_cont, size: 15, class: "form-control js-quick-search-target" %>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="form-group">
+            <%= f.label :variant_sku_cont, Spree.t(:sku) %>
+            <%= f.text_field :variant_sku_cont, size: 15, class: "form-control" %>
+          </div>
+        </div>
+      </div>
+      <div data-hook="admin_stock_items_index_search_buttons" class="form-actions">
+        <%= button Spree.t(:search), 'search' %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<div id='stock-items-div' class='container-fluid' >
+  <div class="row">
+    <%= label_tag Spree.t(:select_stock_location) %>
+    <%= select_tag :stock_location, options_for_select(Spree::StockLocation.all.map { |stock_location| [stock_location.name, stock_location.id, data: { url: admin_stock_items_url(q: search_params, per_page: params[:per_page], stock_location: stock_location.name) }] }, @stock_location.id), class: 'select2', id: 'stock-location-selector', data: { hook: 'stock-location-selector' } %>
+  </div>
+</div>
+
+<div data-hook='admin_stock_inventory_management'>
+  <% if @collection.present? %>
+    <%= render partial: 'stock_items' %>
+  <% else %>
+    <div class="alert alert-info no-objects-found">
+      <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StockItem)) %>
+    </div>
+  <% end %>
+</div>
+
+<%= javascript_include_tag 'spree/backend/stock_inventory_manager' %>

--- a/backend/app/views/spree/admin/stock_items/index.js.erb
+++ b/backend/app/views/spree/admin/stock_items/index.js.erb
@@ -1,0 +1,1 @@
+$('[data-hook="admin_stock_inventory_management"]').html("<%= j(render partial: 'stock_items') %>")

--- a/backend/config/initializers/assets.rb
+++ b/backend/config/initializers/assets.rb
@@ -1,1 +1,5 @@
-Rails.application.config.assets.precompile += %w( admin/* credit_cards/credit_card.gif )
+Rails.application.config.assets.precompile += %w(
+  admin/*
+  credit_cards/credit_card.gif
+  spree/backend/stock_inventory_manager
+)

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -148,7 +148,7 @@ Spree::Core::Engine.add_routes do
       end
     end
 
-    resources :stock_items, only: [:create, :update, :destroy]
+    resources :stock_items
     resources :store_credit_categories
     resources :tax_rates
     resources :trackers
@@ -171,7 +171,6 @@ Spree::Core::Engine.add_routes do
       resources :store_credits
     end
   end
-
   spree_path = Rails.application.routes.url_helpers.try(:spree_path, trailing_slash: true) || '/'
   get Spree.admin_path, to: redirect((spree_path + Spree.admin_path + '/orders').gsub('//', '/')), as: :admin
 end

--- a/backend/spec/features/admin/stock_items/stock_items_spec.rb
+++ b/backend/spec/features/admin/stock_items/stock_items_spec.rb
@@ -1,0 +1,165 @@
+require 'spec_helper'
+
+describe "Stock Items", type: :feature do
+  stub_authorization!
+
+  let!(:stock_location) { create(:stock_location, name: 'Stock Location1') }
+  let!(:stock_location1) { create(:stock_location, name: 'Stock Location2') }
+  let!(:product) { create(:product) }
+  let!(:product1) { create(:product) }
+  let!(:variant) { product.master }
+  let!(:variant1) { product1.master }
+  let!(:stock_item) { variant.stock_items.find_by(stock_location_id: stock_location.id) }
+  let!(:stock_item1) { variant.stock_items.find_by(stock_location_id: stock_location1.id) }
+  let!(:stock_item2) { variant1.stock_items.find_by(stock_location_id: stock_location.id) }
+
+  before do
+    stock_location1.stock_items.where(variant_id: variant1.id).destroy_all
+    visit spree.admin_stock_items_path
+  end
+
+  describe 'listing', js: true do
+    describe 'list stock items with respect to the stock location' do
+      context 'stocks for stock_location' do
+        it { expect(page).to have_content(variant.sku) }
+        it { expect(page).to have_content(variant1.sku) }
+      end
+
+      context 'stocks for stock_location1' do
+        before do
+          select2_search(stock_location1.name, from: 'Select stock location')
+          wait_for_ajax
+        end
+        it { expect(page).to have_content(variant.sku) }
+        it { expect(page).not_to have_content(variant1.sku) }
+      end
+    end
+
+    it 'has delete link' do
+      expect(page).to have_css('.icon-delete')
+    end
+  end
+
+  describe 'searching' do
+    def search(**options)
+      click_on 'Filter'
+      options.each do |field, value|
+        fill_in field.to_s, with: value
+      end
+      click_on 'Search'
+    end
+
+    context 'results present' do
+      context 'search on name' do
+        before do
+          search(q_variant_product_name_cont: variant.name)
+        end
+
+        it { expect(page).to have_content(variant.name) }
+        it { expect(page).not_to have_content(variant1.name) }
+      end
+
+      context 'search on sku' do
+        before do
+          search(q_variant_sku_cont: variant1.sku)
+        end
+
+        it { expect(page).to have_content(variant1.name) }
+        it { expect(page).not_to have_content(variant.name) }
+      end
+
+      context 'search on sku and name both' do
+        before do
+          search(q_variant_sku_cont: variant.sku, q_variant_product_name_cont: variant.name)
+        end
+
+        it { expect(page).not_to have_content(variant1.name) }
+        it { expect(page).to have_content(variant.name) }
+      end
+    end
+
+    context 'result not present' do
+      before do
+        search(q_variant_sku_cont: variant.sku, q_variant_product_name_cont: variant1.name)
+      end
+
+      it { expect(page).not_to have_content(variant.name) }
+      it { expect(page).not_to have_content(variant1.name) }
+      it { expect(page).to have_content('No Stock item found') }
+    end
+  end
+
+  describe 'quantity update', js: true do
+    context 'it is increased' do
+      before do
+        within_row(1) do
+          fill_in 'number_spinner', with: 20
+          click_link 'Save'
+        end
+        wait_for_ajax
+      end
+      it "stock item's current count_on_hand to change to 20" do
+        within_row(1) do
+          expect(page).to have_content(20)
+        end
+      end
+      it 'page has a success message' do
+        expect(page).to have_content(Spree.t(:successfully_created,
+                                             resource: Spree::StockMovement.new.class.model_name.human))
+      end
+    end
+
+    context 'it is decreased' do
+      context 'backorderable' do
+        before do
+          within_row(1) do
+            fill_in 'number_spinner', with: -10
+            click_link 'Save'
+          end
+          wait_for_ajax
+        end
+        it "stock item's current count_on_hand to change to -10" do
+          within_row(1) do
+            expect(page).to have_content(-10)
+          end
+        end
+        it 'page has a success message' do
+          expect(page).to have_content(Spree.t(:successfully_created,
+                                               resource: Spree::StockMovement.new.class.model_name.human))
+        end
+      end
+
+      context 'not backorderable' do
+        before do
+          variant1.stock_items.update_all(backorderable: false)
+          within_row(2) do
+            fill_in 'number_spinner', with: -10
+            click_link 'Save'
+          end
+          wait_for_ajax
+        end
+        it "stock item's current count_on_hand does not change to -10" do
+          within_row(2) do
+            expect(page).not_to have_content(-10)
+          end
+        end
+        it 'page has a failure message' do
+          expect(page).to have_content('Count on hand must be greater than or equal to 0')
+        end
+      end
+    end
+  end
+
+  describe 'delete stock_item', js: true do
+    before do
+      within_row(1) do
+        accept_alert do
+          click_icon :delete
+        end
+      end
+      wait_for_ajax
+    end
+    it { expect(page).to have_content(variant1.sku) }
+    it { expect(page).not_to have_content(variant.sku) }
+  end
+end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -58,6 +58,7 @@ module Spree
     preference :show_variant_full_price, :boolean, default: false #Displays variant full price or difference with product price. Default false to be compatible with older behavior
     preference :show_products_without_price, :boolean, default: false
     preference :show_raw_product_description, :boolean, default: false
+    preference :stock_items_per_page, :integer, default: 15
     preference :tax_using_ship_address, :boolean, default: true
     preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -646,6 +646,7 @@ en:
     currency: Currency
     currency_settings: Currency Settings
     current: Current
+    current_count_on_hand: Current Count On Hand
     current_promotion_usage: ! 'Current Usage: %{count}'
     customer: Customer
     customer_details: Customer Details
@@ -1071,6 +1072,7 @@ en:
     product: Product
     product_details: Product Details
     product_has_no_description: This product has no description
+    product_name: Product Name
     product_not_available_in_this_currency: This product is not available in the selected currency.
     product_properties: Product Properties
     product_rule:
@@ -1248,6 +1250,7 @@ en:
     select_a_stock_location: Select a stock location
     select_a_store_credit_reason: Select a reason for the store credit
     select_stock: Select stock
+    select_stock_location: Select Stock Location
     selected_quantity_not_available: ! 'selected of %{item} is not available.'
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
@@ -1309,6 +1312,7 @@ en:
     show_rate_in_label: Show rate in label
     sku: SKU
     skus: SKUs
+    sku_and_options_text: SKU and Options
     slug: Slug
     source: Source
     special_instructions: Special Instructions

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -23,4 +23,8 @@ describe Spree::AppConfiguration, type: :model do
     it { expect(Spree::Config.preferred_admin_path_type).to eq(:string) }
     it { expect(Spree::Config.preferred_admin_path_default).to eq('/admin') }
   end
+
+  describe 'per_page preferences' do
+    it { expect(Spree::Config.stock_items_per_page).to eq(15) }
+  end
 end


### PR DESCRIPTION
1. Create a side menu tab for Stock Items
2. Create an index page from where a variants stock quantity can be updated
3. Add a checkbox to indicate whether a stock item is backorderable or not.
4. Add a select box to differentiate stock items on the basis of stock location
5. Add a filter specific to stock location to filter stock items on basis of name and sku
6. Add an option to delete the stock item
7. Add pagination and a configuration to maintain stock items per page
8. Bind events dynamically in stock_management.js
9. Add feature specs for the functionality
10. Inherit Spree::Admin::StockItemsController from ResourceController
11. Refactor Spree::Admin::StockItemsController
